### PR TITLE
committee: add batch_id parameter to is_valid hook

### DIFF
--- a/committee/committee/committee.py
+++ b/committee/committee/committee.py
@@ -167,7 +167,7 @@ class Committee:
                     logger.info(f'Waiting for batch {next_batch_id}')
                     await asyncio.sleep(self.polling_interval)
                     continue
-                assert await is_valid(availability_update), 'Third party validation failed.'
+                assert await is_valid(availability_update, next_batch_id), 'Third party validation failed.'
                 signature, availability_claim = await self.validate_data_availability(
                     next_batch_id, availability_update, self.validate_orders)
                 await self.availability_gateway.send_signature(

--- a/committee/committee/custom_validation.py
+++ b/committee/committee/custom_validation.py
@@ -1,7 +1,7 @@
 from starkware.objects.availability import StateUpdate
 
 
-async def is_valid(state_update: StateUpdate) -> bool:
+async def is_valid(state_update: StateUpdate, batch_id: int) -> bool:
     """
     A hook for third parties to validate the state_update before signing the new root.
     """


### PR DESCRIPTION
@MichaelRiabzev-StarkWare as discussed this is necessary in order to pull batch info and obtain last tx id for given batch  