### PR TITLE
[committee] restrict web3 version in Dockerfile to: >=5.28,<6

### DIFF
--- a/committee/Dockerfile
+++ b/committee/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt -y install netcat python-dev libgmp3-dev && apt clean
 # First install the dependencies.
 COPY committee/committee.egg-info/requires.txt /app/committee/
 RUN pip3 install -r /app/committee/requires.txt
-RUN pip3 install web3
+RUN pip install "web3>=5.28,<6"
 
 # Install python packages.
 COPY committee/starkware_crypto-0.1.zip /app/starkware-crypto/


### PR DESCRIPTION
without it, latest version is installed, which causes crash at startup
due to breaking changes in web3 v6